### PR TITLE
Fixes for FCOS 41

### DIFF
--- a/config.butane
+++ b/config.butane
@@ -6,6 +6,37 @@ passwd:
       ssh_authorized_keys:
         - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDyoH6gU4lgEiSiwihyD0Rxk/o5xYIfA3stVDgOGM9N0
 storage:
+  directories:
+    - path: /home/core/.config
+      user:
+        name: core
+      group:
+        name: core
+    - path: /home/core/.config/containers
+      user:
+        name: core
+      group:
+        name: core
+    - path: /home/core/.config/containers/systemd
+      user:
+        name: core
+      group:
+        name: core
+    - path: /home/core/.config/caddy
+      user:
+        name: core
+      group:
+        name: core
+    - path: /home/core/.config/systemd
+      user:
+        name: core
+      group:
+        name: core
+    - path: /home/core/.config/systemd/user
+      user:
+        name: core
+      group:
+        name: core
   links:
     - path: /home/core/.config/systemd/user/timers.target.wants/podman-auto-update.timer
       target: /usr/lib/systemd/user/podman-auto-update.timer
@@ -14,6 +45,9 @@ storage:
       group:
         name: core
   files:
+    - path: /etc/systemd/user/podman-user-wait-network-online.service
+      contents:
+        local: services/podman-user-wait-network-online.service
     - path: /var/lib/systemd/linger/core
       mode: 0644
     - path: /etc/sysctl.d/90-caddy.conf
@@ -62,6 +96,15 @@ storage:
         name: core
 
     - path: /home/core/.config/containers/systemd/wordpress.volume
+      contents:
+        inline: |
+          [Volume]
+      user:
+        name: core
+      group:
+        name: core
+
+    - path: /home/core/.config/containers/systemd/mariadb.volume
       contents:
         inline: |
           [Volume]

--- a/services/podman-user-wait-network-online.service
+++ b/services/podman-user-wait-network-online.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Wait for system level network-online.target as user.
+Documentation=https://github.com/containers/podman/issues/22197
+Documentation=man:podman-systemd.unit(5)
+
+[Service]
+Type=oneshot
+# Set a timeout as by default oneshot does not have one and in case network-online.target
+# never comes online we do not want to block forever, 90s is the default systemd unit timeout.
+TimeoutStartSec=90s
+ExecStart=sh -c 'until ss -l4Hn sport 22 | grep 22; do sleep 0.5; done'
+RemainAfterExit=yes


### PR DESCRIPTION
Here is patch with required fixes for FCOS 41 tested on `Fedora CoreOS 41.20241122.3.0`:

1. Proper ownership of `~/.config/*` subdirectories (recent podman refuses to run containers if owner is not `core` user (without fix these auto-created folders are owned by root)
2. Workaround for failing `podman-user-wait-network-online.service` (on latest FCOS 41 the `network-online.target` does not trigger `is-active` state - related discussion on https://github.com/containers/podman/issues/24796#issuecomment-2562104196
3. Added missing `mariadb.volume` - without it mariadb Quadlet will fail
